### PR TITLE
fix: :bug: Ajuste feito nos logs de resultado que contem propriedades do tipo boolean.

### DIFF
--- a/src/js/penguinDataLayer.js
+++ b/src/js/penguinDataLayer.js
@@ -276,7 +276,7 @@ btnStopPenguinDataLayer.onclick = () => {
                 /* Verify if the event value is in the message with the respective key. */
                 if (Array.isArray(event[key]) || typeof event[key] == 'object') {
                     valueCount++;
-                } else if (typeof event[key] == 'number') {
+                } else if (typeof event[key] == 'number' || typeof event[key] == 'boolean') {
                     if (
                         message.includes(`"${key}":${event[key]},`) ||
                         message.includes(`"${key}":${event[key]}}`)


### PR DESCRIPTION
Os logs de resultado que continham propriedades do tipo boolean, não estavam expandindo pois na verificação do if ele só considerava que as mensagens de propriedade do tipo number vinham sem as aspas.